### PR TITLE
Lock pymongo & txmongo requirements

### DIFF
--- a/hyphe_backend/crawler/Dockerfile
+++ b/hyphe_backend/crawler/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
   && pip install pymongo==2.7 \
   && pip install txmongo==0.6 \
   && pip install selenium==2.42.1 \
-  && pip install Scrapy==0.18 \
+  && pip install Scrapy==0.24.6 \
   && dpkg -i scrapyd_1.0~r0_all.deb
 
 EXPOSE 6800

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ service_identity
 urllib3[secure]
 Twisted>=15.0
 txJSON-RPC
-pymongo>=2.7
-txmongo>=0.6
+pymongo==2.7
+txmongo==0.6


### PR DESCRIPTION
Hi,
we were trying to run it locally using docker-compose, but the backend was throwing some exceptions due to a change in pymongo & txmongo apis. 
I have locked the versions in requirements.txt.

Thanks for the project
andrea