### PR TITLE
Setting to make scrapy ignore/follow robots.txt

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -10,7 +10,8 @@
     "download_delay": 1,
     "store_crawled_html_content": false,
     "max_simul_requests": 12,
-    "max_simul_requests_per_host": 1
+    "max_simul_requests_per_host": 1,
+    "obey_robots": true
   },
   "traph": {
     "keepalive": 1800,

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -45,6 +45,7 @@ if "HYPHE_DOWNLOAD_DELAY"       in environ: setConfig("download_delay", float(en
 if "HYPHE_STORE_CRAWLED_HTML"   in environ: setConfig("store_crawled_html_content", strToBool(environ["HYPHE_STORE_CRAWLED_HTML"]),configdata,"mongo-scrapy")
 if "HYPHE_MAX_SIM_REQ"          in environ: setConfig("max_simul_requests", int(environ["HYPHE_MAX_SIM_REQ"]),configdata,"mongo-scrapy")
 if "HYPHE_HOST_MAX_SIM_REQ"     in environ: setConfig("max_simul_requests_per_host", int(environ["HYPHE_HOST_MAX_SIM_REQ"]),configdata,"mongo-scrapy")
+if "OBEY_ROBOTS"                in environ: setConfig("obey_robots", strToBool(environ["OBEY_ROBOTS"]),configdata,"mongo-scrapy")
 
 if "HYPHE_TRAPH_KEEPALIVE"      in environ: setConfig("keepalive", int(environ["HYPHE_TRAPH_KEEPALIVE"]),configdata,"traph")
 if "HYPHE_TRAPH_DATAPATH"       in environ: setConfig("data_path", environ["HYPHE_TRAPH_DATAPATH"],configdata,"traph")

--- a/hyphe_backend/crawler/hcicrawler/settings-template.py
+++ b/hyphe_backend/crawler/hcicrawler/settings-template.py
@@ -31,6 +31,8 @@ MAX_RESPONSE_SIZE = 5242880 # 5Mb
 
 DUPEFILTER_CLASS = 'hcicrawler.middlewares.CustomDupeFilter'
 
+ROBOTSTXT_OBEY = {{obey_robots}}
+
 MONGO_HOST = '{{host}}'
 MONGO_PORT = {{mongo_port}}
 MONGO_DB = '{{db_name}}_{{project}}'

--- a/hyphe_backend/lib/config_hci.py
+++ b/hyphe_backend/lib/config_hci.py
@@ -43,6 +43,9 @@ def load_config():
         if 'store_crawled_html_content' not in conf['mongo-scrapy']:
             conf['mongo-scrapy']['store_crawled_html_content'] = True
 
+        if 'obey_robots' not in conf['mongo-scrapy']:
+            conf['mongo-scrapy']['obey_robots'] = True
+
   # Set default creation rules if missing
     if "defaultCreationRule" not in conf:
         conf["defaultCreationRule"] = "domain"
@@ -99,7 +102,8 @@ GLOBAL_CONF_SCHEMA = {
     "str_fields": ["host", "proxy_host", "db_name"],
     "extra_fields": {
       "download_delay": float,
-      "store_crawled_html_content": bool
+      "store_crawled_html_content": bool,
+      "obey_robots": bool
     }
   }, "traph": {
     "type": dict,


### PR DESCRIPTION
Fixes #376 .

As far as I could see this does all that's necessary to be able to configure `ROBOTSTXT_OBEY` via config.json, et cetera. It's set to TRUE by default, which is the implicit default for Scrapy.

This doesn't add a way to toggle this via the web interface, but to be honest I'm not sure how to best go about that. For our own purposes being able to toggle it via a config file is sufficient. 

Let me know if I missed any spots where the configuration is processed!