### PR TITLE
The .htpasswd file isn't located in the right place

### DIFF
--- a/hyphe_frontend/docker-entrypoint.sh
+++ b/hyphe_frontend/docker-entrypoint.sh
@@ -26,7 +26,7 @@ chmod -R 550 /frontend/app && chown -R nginx:nginx /frontend/app
 envsubst '\$NS \$BACKEND_HOST \$BACKEND_PORT' < /etc/nginx/conf.d/docker-nginx-vhost.template > /etc/nginx/conf.d/default.conf
 
 [[ ! -z "${HYPHE_HTPASSWORD_USER}" ]] && [[ ! -z "${HYPHE_HTPASSWORD_PASS}" ]] &&
-  printf "${HYPHE_HTPASSWORD_USER}:${HYPHE_HTPASSWORD_PASS}\n" > .htpasswd &&
+  printf "${HYPHE_HTPASSWORD_USER}:${HYPHE_HTPASSWORD_PASS}\n" > /frontend/.htpasswd &&
   sed -r --in-place 's|( location / \{)|\1\n        auth_basic Restricted;\n        auth_basic_user_file /frontend/.htpasswd;|' /etc/nginx/conf.d/default.conf
 
 exec "$@"


### PR DESCRIPTION
After following the [Easy install: using Docker](https://github.com/medialab/hyphe#easy-install-using-docker) procedure with `config-frontend.env` file containing:

```ini
[...]
HYPHE_HTPASSWORD_USER=<USER>
HYPHE_HTPASSWORD_PASS=<PASS>
[...]
```

When I log in to the web interface with the credentials defined in the `config-frontend.env` file, I get the following error (seen with the `docker-compose logs -f` command):

```ini
frontend_1  | 2022/02/27 18:48:49 [error] 21#21: *2 open() "/frontend/.htpasswd" failed (2: No such file or directory), client: <IP>, server: localhost, request: "GET / HTTP/1.1", host: "<HOST>"
```
I was able to solve this problem by moving the `.htpasswd` file to the right place: `docker exec -it --user root <hyphe-container> mv .htpasswd ..`.

Adding the `.htpasswd` absolute path to the `hyphe_frontend/docker-entrypoint.sh` file could be useful to avoid this kind of problem.